### PR TITLE
コンテキストを維持して対話できる関数の追加

### DIFF
--- a/backend/src/constants.go
+++ b/backend/src/constants.go
@@ -20,6 +20,14 @@ const ENDPOINT_LLM_API = "/llm_api"
 const MODEL_PARAM_NAME = "model"   // モデル名
 const PROMPT_PARAM_NAME = "prompt" // プロンプト
 
+// ロール名
+type Role string // ロール名のEnum
+const (
+	System    Role = "system"    // システム
+	User      Role = "user"      // ユーザー
+	Assistant Role = "assistant" // アシスタント
+)
+
 // モデル名
 type ModelName string // モデル名のEnum
 

--- a/backend/src/constants.go
+++ b/backend/src/constants.go
@@ -75,9 +75,17 @@ func (el ErrorLevel) String() string {
 // Presetメッセージを格納するためのKEY
 const KEY_GPT_WORD = "gpt_word"
 
+// チャット開始時刻を格納するためのKEY
+const KEY_CHAT_HISTORY_ORIGIN = "chat_history_origin"
+
+// チャットメッセージを格納するためのKEY
+const KEY_CHAT_HISTORY = "chat_history"
+
 const CONNECTION_PATH = "connection_path"
 
 const ACTION_CHAT_MESSAGE = "chat_message"
+
+const ACTION_RESET_CONTEXT = "reset_context"
 
 const RES_GPT_MESSAGE = "gpt_message"
 const TEST_CHAT_MESSAGE = "test_chat_message"

--- a/backend/src/constants.go
+++ b/backend/src/constants.go
@@ -32,14 +32,17 @@ const (
 type ModelName string // モデル名のEnum
 
 const (
-	GPT3Dot5Turbo ModelName = "gpt3.5-turbo" // GPT3.5 Turbo
-	Davinci       ModelName = "davinci"      // Davinci
+	GPT3Dot5Turbo    ModelName = "gpt-3.5-turbo"     // GPT3.5 Turbo
+	GPT3Dot5Turbo16k ModelName = "gpt-3.5-turbo-16k" // GPT3.5Trubo with 16k window
+	Davinci          ModelName = "davinci"           // Davinci
 )
 
 func strToModel(model string) (ModelName, error) {
 	switch model {
 	case string(GPT3Dot5Turbo):
 		return GPT3Dot5Turbo, nil
+	case string(GPT3Dot5Turbo16k):
+		return GPT3Dot5Turbo16k, nil
 	case string(Davinci):
 		return Davinci, nil
 	default:

--- a/backend/src/gpt.go
+++ b/backend/src/gpt.go
@@ -160,7 +160,7 @@ func savePromptMsg(msg string) (err error) {
 // LLM APIのコントローラ
 func requestPrompt(msg string, history []ChatMessage) (ChatMessage, error) {
 
-	model := "gpt3.5-turbo"
+	model := "gpt-3.5-turbo-16k"
 	prompt := msg
 
 	// modelがModelのどれかに該当するか確認

--- a/backend/src/gpt.go
+++ b/backend/src/gpt.go
@@ -25,8 +25,28 @@ func messagesToJSON(msg []string) ([]Message, error) {
 			slog.Warn("Failed to unmarshal message: %s", err)
 			res[i] = Message{
 				Message: "Failed to unmarshal message",
-				Prompt: "Failed to unmarshal message",
+				Prompt:  "Failed to unmarshal message",
 				Created: 0,
+			}
+		}
+		res[i] = message
+	}
+	return res, nil
+}
+
+func chatmessageToJSON(msg []string) ([]ChatMessage, error) {
+	// 文字列がMessageオブジェクトなのでJSONに変換する
+	res := make([]ChatMessage, len(msg))
+	for i, m := range msg {
+		// Message型にUnmarshalする
+		var message ChatMessage
+		err := json.Unmarshal([]byte(m), &message)
+		if err != nil {
+			// ログに出力する
+			slog.Warn("Failed to unmarshal message: %s", err)
+			res[i] = ChatMessage{
+				Role:    "Failed to unmarshal message",
+				Content: Message{},
 			}
 		}
 		res[i] = message
@@ -46,16 +66,62 @@ func buildPresetUserMessages() ([]Message, error) {
 	return messagesToJSON(presetMessages)
 }
 
-func savePresetMsg(prompt string,msg string) (err error) {
+func getChatHistory(history_origin int64) ([]ChatMessage, error) {
+	history := []ChatMessage{}
+	// history_origin以降のチャット履歴をキャッシュから取得する
+	messages, err := redis.LRange(KEY_CHAT_HISTORY, history_origin, math.MaxInt)
+	if err != nil {
+		return nil, err
+	}
+	// 文字列がMessageオブジェクトなのでJSONに変換する
+	history, err = chatmessageToJSON(messages)
+	if err != nil {
+		return nil, err
+	}
+	return history, nil
+}
+
+func saveChatHistory(history []ChatMessage) (err error) {
+}
+
+func getChatHistoryOrigin() (int64, error) {
+	// キャッシュから会話ログの取り出し
+	history_origin, err := redis.LRange(KEY_CHAT_HISTORY_ORIGIN, 0, 0)
+	if err != nil {
+		return -1, err
+	}
+	// 文字列がMessageオブジェクトなのでJSONに変換する
+	history_origin_int, err := strconv.ParseInt(history_origin[0], 10, 64)
+	if err != nil {
+		return -1, err
+	}
+	return history_origin_int, nil
+}
+
+func setChatHistoryOrigin(history_origin int64) (err error) {
 	// オブジェクトデータの組み立て
-	msgObj := Message{
-		Message: msg,
-		Prompt: prompt,
-		Created: time.Now().Unix(),
+	chatObj := ContextOrigin{
+		Origin: int64(history_origin),
 	}
 
 	// Message型にMarshalする
-	byte_data, err := json.Marshal(msgObj)
+	byte_data, err := json.Marshal(chatObj)
+	if err != nil {
+		return err
+	}
+
+	// redisに格納するデータを作成
+	insert_data := string(byte_data)
+	err = redis.LPush(KEY_CHAT_HISTORY_ORIGIN, insert_data)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func savePresetMsg(msg ChatMessage) (err error) {
+	// Message型にMarshalする
+	byte_data, err := json.Marshal(msg)
 	if err != nil {
 		return err
 	}
@@ -71,9 +137,9 @@ func savePresetMsg(prompt string,msg string) (err error) {
 
 func savePromptMsg(msg string) (err error) {
 	// オブジェクトデータの組み立て
-	msgObj := PromptData{
-		Prompt: msg,
-		Created: time.Now().Unix(),
+	msgObj := ChatMessage{
+		Role:    Assistant,
+		Content: Message{Message: msg, Created: time.Now().Unix()},
 	}
 
 	// Message型にMarshalする
@@ -92,7 +158,7 @@ func savePromptMsg(msg string) (err error) {
 }
 
 // LLM APIのコントローラ
-func requestPrompt(msg string) (string, error) {
+func requestPrompt(msg string, history []ChatMessage) (ChatMessage, error) {
 
 	model := "gpt3.5-turbo"
 	prompt := msg
@@ -100,29 +166,29 @@ func requestPrompt(msg string) (string, error) {
 	// modelがModelのどれかに該当するか確認
 	model_name, err := strToModel(model)
 	if err != nil {
-		return "", err
+		return ChatMessage{}, err
 	}
 
 	openai_token := os.Getenv(API_TOKEN_ENV_NAME_OPENAI)
 	openai_org_id := os.Getenv(OPENAI_ORGANIZATION_ID)
 	max_tokens, err := strconv.Atoi(os.Getenv(STREAM_MAX_TOKENS_ENV_NAME))
 	if err != nil {
-		return "", err
+		return ChatMessage{}, err
 	}
 
 	// OpenAIのAPIにリクエストを投げる
 	log.Println("call llm_api with model: " + model + " and prompt: " + prompt)
 	client := createClient(&http.Client{}, openai_token, openai_org_id)
-	result := ""
+	result := ChatMessage{}
 	err = nil
 	switch model_name {
-	case Davinci:
-		result, err = throwStreamRequest(client, selectModel(model_name), prompt, max_tokens)
 	case GPT3Dot5Turbo:
-		result, err = throwChatStreamRequest(client, selectModel(model_name), prompt, max_tokens)
+		res := []ChatMessage{}
+		res, err = throwChatStreamRequests(client, selectModel(model_name), prompt, max_tokens, history)
+		result = res[len(res)-1]
 	}
 	if err != nil {
-		return "", err
+		return ChatMessage{}, err
 	}
 
 	return result, nil

--- a/backend/src/handler.go
+++ b/backend/src/handler.go
@@ -40,12 +40,16 @@ func handler(s []byte) []byte {
 
 	case requestObject.Action == ACTION_CHAT_MESSAGE:
 		hisotry_origin_int, err := getChatHistoryOrigin()
+		history := []ChatMessage{}
 		if err != nil {
-			slog.Error(err.Error())
-			return errorResponseFactory("faile to fetch chat history", 503, "failed to fetch chat history")
+			slog.Info(err.Error())
+		} else {
+			// キャッシュから会話ログの取り出し
+			history, err = getChatHistory(hisotry_origin_int)
+			if err != nil {
+				slog.Info(err.Error())
+			}
 		}
-		// キャッシュから会話ログの取り出し
-		history, err := getChatHistory(hisotry_origin_int)
 
 		// LLM APIにリクエストを送信する
 		res, err := requestPrompt(requestObject.Message, history)

--- a/backend/src/openai.go
+++ b/backend/src/openai.go
@@ -178,6 +178,8 @@ func selectModel(model_name ModelName) string {
 	switch model_name {
 	case GPT3Dot5Turbo:
 		return openai.GPT3Dot5Turbo
+	case GPT3Dot5Turbo16k:
+		return openai.GPT3Dot5Turbo16K
 	case Davinci:
 		return openai.GPT3Davinci
 	default:

--- a/backend/src/openai.go
+++ b/backend/src/openai.go
@@ -129,7 +129,7 @@ func throwChatStreamRequests(client *openai.Client, model string, prompt string,
 		for _, h := range history {
 			messages = append(messages, openai.ChatCompletionMessage{
 				Role:    roleToOpenAIRole(h.Role),
-				Content: h.Message.Message,
+				Content: h.Content.Message,
 			})
 		}
 	}
@@ -163,7 +163,7 @@ func throwChatStreamRequests(client *openai.Client, model string, prompt string,
 		history,
 		ChatMessage{
 			Role: openai.ChatMessageRoleAssistant,
-			Message: Message{
+			Content: Message{
 				Message: response_text,
 				Created: time.Now().Unix(),
 			},

--- a/backend/src/openai.go
+++ b/backend/src/openai.go
@@ -18,7 +18,7 @@ func createClient(http_client *http.Client, token string, orgID string) *openai.
 	}
 	config.HTTPClient = http_client
 	client := openai.NewClientWithConfig(config)
-	
+
 	return client
 }
 
@@ -112,6 +112,54 @@ func throwChatStreamRequest(client *openai.Client, model string, prompt string, 
 		fmt.Println(resp_i)
 		response += resp_i.Choices[0].Delta.Content
 	}
+	return response, nil
+}
+
+// 対話形式のモデルにEOFが出力されるまでリクエストを投げる。複数回の対話に対応
+func throwChatStreamRequests(client *openai.Client, model string, prompt string, max_tokens int, history []openai.ChatCompletionMessage) ([]openai.ChatCompletionMessage, error) {
+	messages := []openai.ChatCompletionMessage{
+		{
+			Role:    openai.ChatMessageRoleUser,
+			Content: prompt,
+		},
+	}
+	// if the history exists, insert history at first index of messages
+	if len(history) > 0 {
+		messages = append(messages, history...)
+	}
+	stream, err := client.CreateChatCompletionStream(
+		context.Background(),
+		openai.ChatCompletionRequest{
+			Model:     model,
+			Messages:  messages,
+			Stream:    true,
+			MaxTokens: max_tokens,
+		},
+	)
+	if err != nil {
+		return messages, err
+	}
+
+	defer stream.Close()
+	response_text := ""
+	for {
+		resp_i, err := stream.Recv()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				return messages, err
+			}
+			break
+		}
+		fmt.Println(resp_i)
+		response_text += resp_i.Choices[0].Delta.Content
+	}
+	response := append(
+		messages,
+		openai.ChatCompletionMessage{
+			Role:    openai.ChatMessageRoleAssistant,
+			Content: response_text,
+		})
+
 	return response, nil
 }
 

--- a/backend/src/type.go
+++ b/backend/src/type.go
@@ -3,8 +3,8 @@ package main
 import "github.com/gorilla/websocket"
 
 type ChatMessage struct {
-	Role    Role    `string:"role"`
-	Message Message `json:"message"`
+	Role    Role    `json:"role"`
+	Content Message `json:"content"`
 }
 
 type Message struct {

--- a/backend/src/type.go
+++ b/backend/src/type.go
@@ -9,12 +9,16 @@ type ChatMessage struct {
 
 type Message struct {
 	Message string `json:"message"`
-	Prompt string `json:"prompt"`
+	Prompt  string `json:"prompt"`
 	Created int64  `json:"created_at"`
 }
 
+type ContextOrigin struct {
+	Origin int64 `json:"origin"`
+}
+
 type PromptData struct {
-	Prompt string `json:"prompt"`
+	Prompt  string `json:"prompt"`
 	Created int64  `json:"created_at"`
 }
 
@@ -38,7 +42,7 @@ type ChatResponse struct {
 	Action  string `json:"action"`
 	Message string `json:"message"`
 	Created int64  `json:"created_at"`
-	Prompt string `json:"prompt"`
+	Prompt  string `json:"prompt"`
 }
 
 // WebSocket関連

--- a/backend/src/type.go
+++ b/backend/src/type.go
@@ -2,6 +2,11 @@ package main
 
 import "github.com/gorilla/websocket"
 
+type ChatMessage struct {
+	Role    Role    `string:"role"`
+	Message Message `json:"message"`
+}
+
 type Message struct {
 	Message string `json:"message"`
 	Created int64  `json:"created_at"`


### PR DESCRIPTION
throwChatStreamRequests()を実装。
引数と戻り値に[]openai.ChatCompletionMessage型で既存メッセージのやり取りができるようにした。